### PR TITLE
ceph-deploy missing no-adjust-repos flag

### DIFF
--- a/manifests/baseconfig.pp
+++ b/manifests/baseconfig.pp
@@ -106,14 +106,14 @@ class cephdeploy::baseconfig(
 
   exec { "install ceph":
     cwd     => "/home/$user/bootstrap",
-    command => "/usr/local/bin/ceph-deploy install $::hostname",
+    command => "/usr/bin/ceph-deploy install --no-adjust-repos $::hostname",
     unless  => '/usr/bin/dpkg -l | grep ceph-common',
     require => File["ceph.mon.keyring"],
   }
 
   exec {'gatherkeys':
     cwd     => "/home/$user/bootstrap",
-    command => "/usr/local/bin/ceph-deploy gatherkeys $::ceph_primary_mon",
+    command => "/usr/bin/ceph-deploy gatherkeys $::ceph_primary_mon",
     unless  => '/usr/bin/test -e /etc/ceph/ceph.client.admin.keyring',
     user     => $user,
     require => Exec['install ceph'],

--- a/manifests/mds.pp
+++ b/manifests/mds.pp
@@ -6,7 +6,7 @@ class cephdeploy::mds(
 
   exec { 'create mds':
     cwd     => "/home/$user/bootstrap",
-    command => "/usr/local/bin/ceph-deploy mds create $::hostname",
+    command => "/usr/bin/ceph-deploy mds create $::hostname",
     unless  => '/bin/ps -ef | /bin/grep -v grep | /bin/grep ceph-mds',
     require => Exec['install ceph'],
     provider => shell,


### PR DESCRIPTION
ceph-deploy is missing the --no-adjust-repos flag so it will try to use
the Ceph master repos rather than the default preconfigured system repos
for package installation.

Additionally, paths are wrong in several Exec statements related to
ceph-deploy.

Partial-Bug: #1289569
