### PR TITLE
dpkg call fails on RHEL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,7 +138,7 @@ class cephdeploy(
   exec { "install ceph":
     cwd     => "/home/$user/bootstrap",
     command => "/usr/bin/ceph-deploy install --no-adjust-repos $::hostname",
-    unless  => '/usr/bin/dpkg -l | grep ceph-common',
+    unless  => '/usr/bin/test -f /usr/bin/ceph',
     require => [ Package['ceph-deploy'], File['ceph.mon.keyring'], File["/home/$user/bootstrap"] ],
   }
 


### PR DESCRIPTION
Replace dpkg-based test with platform-independent test.

Closes-Bug: #1340164
