### PR TITLE
Configure CRUSH map appropriately on AIO Ceph

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,14 @@
+# == Class: cephdeploy
+#
+# Installs and configures ceph using ceph-deploy
+#
+# === Parameters:
+#
+# [*singlenode*]
+#  (optional) Tune CRUSH map to work on single-node Ceph deployments
+#  Defaults to undefined
+#
+
 class cephdeploy(
   $user                 = hiera('ceph_deploy_user'),
   $ceph_deploy_user     = hiera('ceph_deploy_user'),
@@ -10,6 +21,7 @@ class cephdeploy(
   $ceph_cluster_network = hiera('ceph_cluster_network'),
   $ceph_monitor_secret  = hiera('ceph_monitor_secret'),
   $has_compute          = false,
+  $singlenode           = undef,
 ){
 
 ## User setup

--- a/templates/ceph.conf.erb
+++ b/templates/ceph.conf.erb
@@ -7,3 +7,6 @@ osd journal size = 1024
 filestore xattr use omap = true
 public network = <%= @ceph_public_network %>
 cluster network = <%= @ceph_cluster_network %>
+<% if @singlenode -%>
+osd crush chooseleaf type = 0
+<% end -%>


### PR DESCRIPTION
Introduce a parameter which can be used to set up the CRUSH map
optimally in single-node Ceph installations. This allows AIO Ceph
installs to report HEALTH_OK.

Closes-Bug: 1340168
